### PR TITLE
add: qrcodePayload no guiaresult

### DIFF
--- a/src/OpenAC.Net.GNRe/Commom/GuiaResult.cs
+++ b/src/OpenAC.Net.GNRe/Commom/GuiaResult.cs
@@ -194,6 +194,9 @@ namespace OpenAC.Net.GNRe.Commom
         [DFeElement(TipoCampo.Str, "codigoBarras")]
         public string CodigoBarras { get; set; }
 
+        [DFeElement(TipoCampo.Str, "qrcodePayload")]
+        public string QrCodePayload { get; set; }
+
         [DFeCollection("motivosRejeicao")]
         [DFeItem(typeof(Motivo), "motivo")]
         public List<Motivo> MotivosRejeicao { get; set; }


### PR DESCRIPTION
add: permite serializar campo qrcodePayload no retorno da emissão da guia